### PR TITLE
@dblock: Fix failing twilio route spec

### DIFF
--- a/apps/home/test/routes.coffee
+++ b/apps/home/test/routes.coffee
@@ -33,10 +33,7 @@ describe '#sendLinkViaSMS', ->
     routes.sendLinkViaSMS { body: { phone_number: '555 111 2222' } }, { json: resStub = sinon.stub() }
 
   it 'sends a link with a valid phone number', ->
-    twilioConstructorArgs[0].length.should.be.above 5
-    twilioConstructorArgs[1].length.should.be.above 5
     twilioSendSmsArgs[0].to.should.equal '555 111 2222'
-    twilioSendSmsArgs[0].from.should.equal '(917) 746-8750'
     twilioSendSmsArgs[0].body.should.include "Download the new Artsy iPhone app here: "
     twilioSendSmsArgs[1] null, 'SUCCESS!'
     resStub.args[0][1].message.should.include 'Message sent.'


### PR DESCRIPTION
Sorry this test isn't very clear and should have been broken up into multiple tests. These were failing because it was testing config values that were removed from conflg.coffee I assume because we open sourced this and don't want to expose those.
