### PR TITLE
@craigspaeth Fix safari flickering when modifying the hero element while it is covered

### DIFF
--- a/apps/home/client/view.coffee
+++ b/apps/home/client/view.coffee
@@ -133,11 +133,24 @@ module.exports = class HomePageView extends Backbone.View
 
     # add / remove the 'bottom mode' state
     if @scrollTop > @documentHeight - (@browserHeight * 2)
-      unless @$hero.hasClass 'bottom-mode'
-        @$hero.addClass 'bottom-mode'
-        @carouselView.showFirstSplashImage()
+      @setHeroBottomMode true
     else
-      @$hero.removeClass 'bottom-mode'
+      @setHeroBottomMode false
+
+  # we hide the element then add the class then defer a show.
+  # this fixes flickering in safari when modifying covered dom nodes
+  setHeroBottomMode: (enabled) ->
+    if enabled
+      unless @$hero.hasClass 'bottom-mode'
+        @$hero.hide().addClass 'bottom-mode'
+        _.defer =>
+          @$hero.show()
+        @carouselView.showFirstSplashImage()
+
+    else if @$hero.hasClass 'bottom-mode'
+      @$hero.hide().removeClass 'bottom-mode'
+      _.defer =>
+        @$hero.show()
 
   animate: =>
     newScrollTop = @$window.scrollTop()


### PR DESCRIPTION
Repro: In safari, scroll to the bottom of the page. When the 'bottom-mode' class is added or removed from the hero unit, the hero will be z-indexed to the top for a split second causing an odd black flash.

To fix this, we hide the dom node and then in a setTimeout (a _.defer), we add the 'bottom-mode' class. This fixes the flickering. WTF SAFARI.

Apparently, if you modify a dom element in Safari temporarily gets z-indexed to the top (?)
